### PR TITLE
CH322437 - set empty beforeState to null rather than undefined so nextjs can serialize it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const isOptimistState = state => state && Object.keys(state).length === 3
 export const ensureState = state => isOptimistState(state) ? state.current : state;
 
 const createState = state => ({
-  beforeState: undefined,
+  beforeState: null,
   history: [],
   current: state
 });
@@ -28,7 +28,7 @@ const applyCommit = (state, targetActionIndex, reducer) => {
       return {
         ...state,
         history: [],
-        beforeState: undefined
+        beforeState: null
       };
     }
     // Create a new history starting with the next one
@@ -73,7 +73,7 @@ const applyRevert = (state, targetActionIndex, reducer) => {
         ...state,
         history: [],
         current: historyWithoutRevert.reduce((s, action) => reducer(s, action), beforeState),
-        beforeState: undefined
+        beforeState: null
       };
     }
     newHistory = historyWithoutRevert.slice(nextOptimisticIndex);


### PR DESCRIPTION
https://app.clubhouse.io/shipt/story/322437/update-reduct-optimistic-ui-library-to-allow-serializing-redux-by-nextjs

ref: this next js issue: https://github.com/vercel/next.js/discussions/11209

The problem is that we want to pass our redux state through next's SSR->browser data initialization system, but that system refuses to serialize `undefined`.  The vercel issue's discussion makes it apparent how contentious this policy is; perhaps it will update in the future.  Until then, we can use this fork to handle our own optimistic update needs (without needing to beg for an npm update).